### PR TITLE
Adding new lambda examples - Example of bad squash merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ generate-lambda-template my-new-lambda-function
 ```
 
 Follow the prompt.
+
+# What does it create?
+
+It will create a folder with files for whichever lambda function example you choose.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Follow the prompt.
 ## What does it create?
 
 It will create a folder with files for whichever lambda function example you choose.
+
+## Frameworks
+
+At the moment, all the templates use [serverless](https://www.serverless.com/). We are working towards adding different frameworks in the future. Stay tuned!

--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ generate-lambda-template my-new-lambda-function
 
 Follow the prompt.
 
-# What does it create?
+## What does it create?
 
 It will create a folder with files for whichever lambda function example you choose.

--- a/lib/data/index.js
+++ b/lib/data/index.js
@@ -33,6 +33,15 @@ const templateData = [
           frameworkId: '1',
           frameworkName: 'serverless'
         }
+      },
+      {
+        templateId: '4',
+        templateName: 'step-function-schedule-lambda-every-30s',
+        url: 'aws-lambda-template-generator/ts-step-functions-schedule-lambda-every-30sec',
+        framework: {
+          frameworkId: '1',
+          frameworkName: 'serverless'
+        }
       }
     ]
   },
@@ -45,6 +54,15 @@ const templateData = [
         templateId: '1',
         templateName: 'simple-api-proxy',
         url: 'aws-lambda-template-generator/js-simple-api-proxy-template',
+        framework: {
+          frameworkId: '1',
+          frameworkName: 'serverless'
+        }
+      },
+      {
+        templateId: '2',
+        templateName: 'step-function-schedule-lambda-every-30s',
+        url: 'aws-lambda-template-generator/js-step-functions-schedule-lambda-every-30sec',
         framework: {
           frameworkId: '1',
           frameworkName: 'serverless'

--- a/lib/data/index.js
+++ b/lib/data/index.js
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 'use strict';
 
-
 const templateData = [
   // TypeScript
   {

--- a/lib/data/index.js
+++ b/lib/data/index.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
+
 const templateData = [
   // TypeScript
   {

--- a/lib/utils/gitDownloader.js
+++ b/lib/utils/gitDownloader.js
@@ -19,4 +19,3 @@ const gitDownloader = async(repoUrl, outputPath) => {
 module.exports = {
   gitDownloader
 };
-

--- a/lib/utils/gitDownloader.js
+++ b/lib/utils/gitDownloader.js
@@ -19,3 +19,4 @@ const gitDownloader = async(repoUrl, outputPath) => {
 module.exports = {
   gitDownloader
 };
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-lambda-template-generator",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "AWS Lambda template generator",
   "main": "index.js",
   "homepage": "https://github.com/aws-lambda-template-generator",


### PR DESCRIPTION
Added a new lambda examples in the data.

This PR is to show bad commit history.

- Made a bunch of small commit with useless messages
- Used the squash merge option with git

Although the main branch history shows one commit, the PR contains many commits that are unhelpful to go through.